### PR TITLE
Add more systems to update

### DIFF
--- a/runUpdates.sh
+++ b/runUpdates.sh
@@ -6,17 +6,17 @@ echo "Update ipsum dolor sit amet"
 
 ## Examples
 
-# Homebrew (https://brew.sh) 
+# Cocoapods spec repo (https://cocoapods.org)
+# echo "Cocoapods spec repo"
+# pod repo update
+
+# Homebrew (https://brew.sh)
 # echo "Homebrew"
 # brew update && brew upgrade
 
 # Homebrew cask (http://caskroom.github.io)
 # echo "Brew cask"
 # brew cask upgrade
-
-# Cocoapods spec repo (https://cocoapods.org)
-# echo "Cocoapods spec repo"
-# pod repo update
 
 # Mac App Store software (https://github.com/mas-cli/mas)
 # echo "Mac App Store"

--- a/runUpdates.sh
+++ b/runUpdates.sh
@@ -6,6 +6,18 @@ echo "Update ipsum dolor sit amet"
 
 ## Examples
 
+# Arch Linux (https://www.archlinux.org/)
+# echo "Pacman"
+# pacman -Syu --noconfirm
+
+# Atom packages (https://atom.io)
+# echo "Atom packages"
+# apm upgrade --no-confirm
+
+# Debian based systems like Ubuntu, Linux Mint, Raspbian and more (https://www.debian.org/)
+# echo "APT"
+# apt update && apt upgrade -y
+
 # Cocoapods spec repo (https://cocoapods.org)
 # echo "Cocoapods spec repo"
 # pod repo update
@@ -21,6 +33,10 @@ echo "Update ipsum dolor sit amet"
 # Mac App Store software (https://github.com/mas-cli/mas)
 # echo "Mac App Store"
 # mas upgrade
+
+# Node Package Manager (https://npmjs.com)
+# echo "NPM"
+# npm upgrade -g
 
 # Rubygems (https://rubygems.org)
 # echo "ruby gems"


### PR DESCRIPTION
added systems:
* Arch Linux (pacman)
* Atom packages (apm)
* Debian based (apt)
* Node Package Manager (npm)

All of these commands are without user confirmation. This could result in unwanted updates (some companies require some legacy versions that shouldn't be updated until all do). Also it could be helpful to know what will be updated in order to know what things on your system can do (or not anymore).

**Question**: should all example commands update without user interaction or should they require user confirmation?