### PR TITLE
add git fetch of repositories below folder

### DIFF
--- a/runUpdates.sh
+++ b/runUpdates.sh
@@ -41,3 +41,7 @@ echo "Update ipsum dolor sit amet"
 # Rubygems (https://rubygems.org)
 # echo "ruby gems"
 # gem update
+
+# Fetch all git Repositories below folder (https://git-scm.com)
+# echo "git fetch"
+# find ~/git -name ".git" -type d -print -exec git -C {}/../ fetch --all \;


### PR DESCRIPTION
Script using `find` to get all the git repositories below a folder (in the default case `~/git`).

A git folder is defined here as a directory which contains a `.git` directory. Within the `.git` folder execute `git fetch --all` with `-C` to indicate the parent folder of `.git` is the actual git repository.

Also prints each `.git` folder it found.