### PR TITLE
don't update while on battery

### DIFF
--- a/didYouUpdate.sh
+++ b/didYouUpdate.sh
@@ -12,6 +12,12 @@ updateFilePath="$scriptDirectory/$updateFile"
 
 ####### MAIN ########
 
+## MacOS Battery check
+# battery=$(pmset -g batt)
+# if [[ $battery == *"Now drawing from 'Battery Power'"* ]]; then
+#   exit
+# fi
+
 # Create file if it doesn't exist yet
 if ! [ -e ${lastUpdateFilePath} ]
 then


### PR DESCRIPTION
While I'm on the go I don't want to update something.

First I thought about requiring WiFi for updates but updating can draw a lot of power too. Also when power is available network connection is probably available too.

This should be commented out per default as this differs based on the OS of the user.